### PR TITLE
fix: `FileOrStdin` generic inner and deref.

### DIFF
--- a/src/file_or_stdin.rs
+++ b/src/file_or_stdin.rs
@@ -71,9 +71,9 @@ where
     }
 }
 
-impl FileOrStdin {
+impl<T> FileOrStdin<T> {
     /// Extract the inner value from the wrapper
-    pub fn into_inner(self) -> String {
+    pub fn into_inner(self) -> T {
         self.inner
     }
 }
@@ -96,8 +96,8 @@ where
     }
 }
 
-impl std::ops::Deref for FileOrStdin {
-    type Target = String;
+impl<T> std::ops::Deref for FileOrStdin<T> {
+    type Target = T;
 
     fn deref(&self) -> &Self::Target {
         &self.inner


### PR DESCRIPTION
This fixes `FileOrStdin` to return the correct type instead of always assuming `String`.

I don't know if there are additional tests that you wanted to add, but I believe this fix was the intended behavior. If this isn't the intended behavior, feel free to close/disregard this PR.