### PR TITLE
Adding Read support to FileOrStdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,26 @@ use clap_stdin::FileOrStdin;
 
 #[derive(Debug, Parser)]
 struct Args {
-    contents: FileOrStdin,
+    input: FileOrStdin,
 }
 
+# fn main() -> anyhow::Result<()> {
 let args = Args::parse();
-println!("contents={}", args.contents);
+println!("input={}", args.input.contents()?);
+# Ok(())
+# }
 ```
 
 Calling this CLI:
 ```sh
 # using stdin for positional arg value
 $ echo "testing" | cargo run -- -
-contents=testing
+input=testing
 
 # using filename for positional arg value
-$ echo "testing" > contents.txt
-$ cargo run -- contents.txt
-contents=testing
+$ echo "testing" > input.txt
+$ cargo run -- input.txt
+input=testing
 ```
 
 ## Compatible Types
@@ -98,6 +101,39 @@ $ wc ~/myfile.txt -l | ./example -
 $ cat myfile.txt
 42
 $ .example myfile.txt
+```
+
+## Reading from Stdin without special characters
+When using [`MaybeStdin`] or [`FileOrStdin`], you can allow your users to omit the "-" character to read from `stdin` by providing a `default_value` to clap. This works with positional and optional args:
+
+```rust,no_run
+use clap::Parser;
+
+use clap_stdin::FileOrStdin;
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[clap(default_value = "-")]
+    input: FileOrStdin,
+}
+
+# fn main() -> anyhow::Result<()> {
+let args = Args::parse();
+println!("input={}", args.input.contents()?);
+# Ok(())
+# }
+```
+
+Calling this CLI:
+```sh
+# using stdin for positional arg value
+$ echo "testing" | cargo run
+input=testing
+
+# using filename for positional arg value
+$ echo "testing" > input.txt
+$ cargo run -- input.txt
+input=testing
 ```
 
 ## Using `MaybeStdin` or `FileOrStdin` multiple times

--- a/examples/parse_with_serde.rs
+++ b/examples/parse_with_serde.rs
@@ -41,6 +41,6 @@ struct Args {
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    eprintln!("{:?}", args.user);
+    eprintln!("{:?}", args.user.contents());
     Ok(())
 }

--- a/tests/fixtures/file_or_stdin_optional_arg.rs
+++ b/tests/fixtures/file_or_stdin_optional_arg.rs
@@ -11,5 +11,9 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    println!("{args:?}");
+    println!(
+        "FIRST: {}, SECOND: {:?}",
+        args.first,
+        args.second.map(|second| second.contents().unwrap()),
+    );
 }

--- a/tests/fixtures/file_or_stdin_positional_arg.rs
+++ b/tests/fixtures/file_or_stdin_positional_arg.rs
@@ -4,6 +4,7 @@ use clap_stdin::FileOrStdin;
 
 #[derive(Debug, Parser)]
 struct Args {
+    #[clap(default_value = "-")]
     first: FileOrStdin,
     #[clap(short, long)]
     second: Option<String>,
@@ -11,5 +12,9 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    println!("{args:?}");
+    println!(
+        "FIRST: {}; SECOND: {:?}",
+        args.first.contents().unwrap(),
+        args.second
+    );
 }

--- a/tests/fixtures/file_or_stdin_twice.rs
+++ b/tests/fixtures/file_or_stdin_twice.rs
@@ -10,5 +10,9 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    println!("{args:?}");
+    println!(
+        "FIRST: {}; SECOND: {}",
+        args.first.contents().unwrap(),
+        args.second
+    );
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -109,16 +109,16 @@ fn test_file_or_stdin_positional_arg() {
         .assert()
         .success()
         .stdout(predicate::str::starts_with(
-            r#"Args { first: "FILE", second: Some("SECOND") }"#,
+            r#"FIRST: FILE; SECOND: Some("SECOND")"#,
         ));
     Command::cargo_bin("file_or_stdin_positional_arg")
         .unwrap()
-        .args(["-", "--second", "SECOND"])
+        .args(["--second", "SECOND"])
         .write_stdin("STDIN")
         .assert()
         .success()
         .stdout(predicate::str::starts_with(
-            r#"Args { first: "STDIN", second: Some("SECOND") }"#,
+            r#"FIRST: STDIN; SECOND: Some("SECOND")"#,
         ));
     Command::cargo_bin("file_or_stdin_positional_arg")
         .unwrap()
@@ -126,9 +126,7 @@ fn test_file_or_stdin_positional_arg() {
         .write_stdin("TESTING")
         .assert()
         .success()
-        .stdout(predicate::str::starts_with(
-            r#"Args { first: "FILE", second: None }"#,
-        ));
+        .stdout(predicate::str::starts_with(r#"FIRST: FILE; SECOND: None"#));
 }
 
 #[test]
@@ -144,7 +142,7 @@ fn test_file_or_stdin_optional_arg() {
         .assert()
         .success()
         .stdout(predicate::str::starts_with(
-            r#"Args { first: "FIRST", second: Some(2) }"#,
+            r#"FIRST: FIRST, SECOND: Some(2)"#,
         ));
     Command::cargo_bin("file_or_stdin_optional_arg")
         .unwrap()
@@ -153,7 +151,7 @@ fn test_file_or_stdin_optional_arg() {
         .assert()
         .success()
         .stdout(predicate::str::starts_with(
-            r#"Args { first: "FIRST", second: Some(2) }"#,
+            r#"FIRST: FIRST, SECOND: Some(2)"#,
         ));
     Command::cargo_bin("file_or_stdin_optional_arg")
         .unwrap()
@@ -161,9 +159,7 @@ fn test_file_or_stdin_optional_arg() {
         .write_stdin("TESTING")
         .assert()
         .success()
-        .stdout(predicate::str::starts_with(
-            r#"Args { first: "FIRST", second: None }"#,
-        ));
+        .stdout(predicate::str::starts_with(r#"FIRST: FIRST, SECOND: None"#));
 }
 
 #[test]
@@ -177,18 +173,14 @@ fn test_file_or_stdin_twice() {
         .args([&tmp_path, "2"])
         .assert()
         .success()
-        .stdout(predicate::str::starts_with(
-            r#"Args { first: "FILE", second: 2 }"#,
-        ));
+        .stdout(predicate::str::starts_with(r#"FIRST: FILE; SECOND: 2"#));
     Command::cargo_bin("file_or_stdin_twice")
         .unwrap()
         .write_stdin("2")
         .args([&tmp_path, "-"])
         .assert()
         .success()
-        .stdout(predicate::str::starts_with(
-            r#"Args { first: "FILE", second: 2 }"#,
-        ));
+        .stdout(predicate::str::starts_with(r#"FIRST: FILE; SECOND: 2"#));
 
     // Actually using stdin twice will fail because there's no value the second time
     Command::cargo_bin("file_or_stdin_twice")


### PR DESCRIPTION
Instead of making `FileOrStdin` read in the entire stdin/file contents with `fs::read_to_string`, this commit adds support to use `io::Read` on the input `Source` via `FileOrStdin::into_reader`.  Existing functionality is preserved, although with a new function `FileOrStdin::contents`.