### PR TITLE
Add Tokio support to FileOrStdin

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,8 +26,6 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: lint
       run: make lint
-    - name: clippy
-      run: cargo clippy --all-features --no-deps -- -D warnings
     - name: build (lib)
       run: cargo build --verbose
     - name: test
@@ -35,6 +33,4 @@ jobs:
         RUST_LOG: info
       run: make test
     - name: document
-      env:
-        RUSTDOCFLAGS: "-Dwarnings"
-      run: cargo doc --all-features
+      run: make doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,34 @@ repository = "https://github.com/thepacketgeek/clap-stdin"
 
 [features]
 default = []
+tokio = ["dep:tokio"]
 # This feature is used for testing with the bins below, since they are linked with deps and not dev-deps
 test_bin = ["clap"]
+test_bin_tokio = ["clap", "tokio"]
 
 [dependencies]
 thiserror = "1.0.40"
 clap = { version = "4.2.1", features = ["derive"], optional = true }
+tokio = { version = "1.35.1", features = [
+    "fs",
+    "io-std",
+    "io-util",
+], optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
 assert_cmd = "2.0.10"
 predicates = "3.0.2"
-clap = { version = "4.2.1", features = ["derive"]}
+clap = { version = "4.2.1", features = ["derive"] }
 tempfile = "3.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio = { version = "1.35.1", features = ["rt", "macros"] }
+
+
+[[example]]
+name = "parse_with_serde"
+required-features = ["default"]
 
 # These bins are only used for testing
 [[bin]]

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,15 @@ test: lint
 	cargo test --features tokio
 
 doc:
-	cargo doc
+	cargo doc --features tokio
 
 lint:
 	cargo fmt --message-format human -- --check
 	cargo check
-	RUSTDOCFLAGS=-Dwarnings cargo doc -q --no-deps --lib
+	cargo check --features tokio
+	RUSTDOCFLAGS=-Dwarnings cargo doc -q --no-deps --lib --features tokio
 	cargo clippy -q --no-deps -- -D warnings
+	cargo clippy -q --no-deps --features tokio -- -D warnings
 
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 test: lint
 # tests use the binaries so we need to build them first
 	cargo build --bins --features test_bin
-	cargo test --features test_bin
+	cargo test
+	cargo build --bins --features test_bin_tokio
+	cargo test --features tokio
 
 doc:
 	cargo doc

--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ $ cargo run -- input.txt
 input=testing
 ```
 
-## Using `MaybeStdin` or `FileOrStdin` multiple times
+## Async Support
+`FileOrStdin` can also be used with [`tokio::io::AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html) using the `tokio` feature. See [`FileOrStdin::contents_async`] and [`FileOrStdin::into_async_reader`] for examples.
+
+# Using `MaybeStdin` or `FileOrStdin` multiple times
 Both [`MaybeStdin`] and [`FileOrStdin`] will check at runtime if `stdin` is being read from multiple times. You can use this
 as a feature if you have mutually exclusive args that should both be able to read from stdin, but know
 that the user will receive an error if 2+ `MaybeStdin` args receive the "-" value.

--- a/examples/parse_with_serde.rs
+++ b/examples/parse_with_serde.rs
@@ -6,12 +6,15 @@
 //! Example usage:
 //! ```sh
 //! # via stdin
-//! $ echo '{ "name": "Trinity", "age": 30 }' | cargo run --example parse_with_serde -- -
+//! $ echo '{ "name": "Trinity", "age": 30 }' | cargo run --example parse_with_serde
 //!
 //! # via file read
 //! $ cat contents.json
 //! '{ "name": "Trinity", "age": 30 }'
 //! $ cargo run --example parse_with_serde -- ./contents.json
+//!
+//! # Using tokio AsyncRead
+//! $ cargo run --features tokio --example parse_with_serde -- ./contents.json
 //! ```
 use std::str::FromStr;
 
@@ -35,7 +38,8 @@ impl FromStr for User {
 
 #[derive(Debug, Parser)]
 struct Args {
-    /// Parsed user from a file or stdin json
+    /// Parsed user from json, provided via a filepath (or leave blank to read from stdin)
+    #[clap(default_value = "-")]
     user: FileOrStdin<User>,
 }
 

--- a/examples/parse_with_serde.rs
+++ b/examples/parse_with_serde.rs
@@ -39,8 +39,17 @@ struct Args {
     user: FileOrStdin<User>,
 }
 
+#[cfg(not(feature = "tokio"))]
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    eprintln!("{:?}", args.user.contents());
+    eprintln!("{:?}", args.user.contents()?);
+    Ok(())
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    eprintln!("{:?}", args.user.contents_async().await?);
     Ok(())
 }

--- a/src/file_or_stdin.rs
+++ b/src/file_or_stdin.rs
@@ -90,6 +90,22 @@ impl<T> FileOrStdin<T> {
 
     #[cfg(feature = "tokio")]
     /// Read the entire contents from the input source, returning T::from_str
+    /// ```rust,no_run
+    /// use clap::Parser;
+    /// use clap_stdin::FileOrStdin;
+    ///
+    /// #[derive(Debug, Parser)]
+    /// struct Args {
+    ///     input: FileOrStdin,
+    /// }
+    ///
+    /// # #[tokio::main(flavor = "current_thread")]
+    /// # async fn main() -> anyhow::Result<()> {
+    /// let args = Args::parse();
+    /// println!("input={}", args.input.contents_async().await?);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn contents_async(self) -> Result<T, StdinError>
     where
         T: FromStr,

--- a/src/file_or_stdin.rs
+++ b/src/file_or_stdin.rs
@@ -1,7 +1,8 @@
-use std::fs;
-use std::io::{self, Read};
 use std::marker::PhantomData;
 use std::str::FromStr;
+
+#[cfg(feature = "tokio")]
+use tokio::io::AsyncReadExt;
 
 use super::{Source, StdinError};
 
@@ -47,6 +48,7 @@ impl<T> FileOrStdin<T> {
         T: FromStr,
         <T as FromStr>::Err: std::fmt::Display,
     {
+        use std::io::Read;
         let mut reader = self.into_reader()?;
         let mut input = String::new();
         let _ = reader.read_to_string(&mut input)?;
@@ -75,12 +77,61 @@ impl<T> FileOrStdin<T> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn into_reader(&self) -> Result<impl io::Read, StdinError> {
+    pub fn into_reader(&self) -> Result<impl std::io::Read, StdinError> {
         let input: Box<dyn std::io::Read + 'static> = match &self.source {
             Source::Stdin => Box::new(std::io::stdin()),
             Source::Arg(filepath) => {
-                let f = fs::File::open(filepath)?;
+                let f = std::fs::File::open(filepath)?;
                 Box::new(f)
+            }
+        };
+        Ok(input)
+    }
+
+    #[cfg(feature = "tokio")]
+    /// Read the entire contents from the input source, returning T::from_str
+    pub async fn contents_async(self) -> Result<T, StdinError>
+    where
+        T: FromStr,
+        <T as FromStr>::Err: std::fmt::Display,
+    {
+        let mut reader = self.into_async_reader().await?;
+        let mut input = String::new();
+        let _ = reader.read_to_string(&mut input).await?;
+        T::from_str(input.trim_end()).map_err(|e| StdinError::FromStr(format!("{e}")))
+    }
+
+    #[cfg(feature = "tokio")]
+    /// Create a reader from the source, to allow user flexibility of
+    /// how to read and parse (e.g. all at once or in chunks)
+    ///
+    /// ```no_run
+    /// use std::io::Read;
+    /// use tokio::io::AsyncReadExt;
+    ///
+    /// use clap_stdin::FileOrStdin;
+    /// use clap::Parser;
+    ///
+    /// #[derive(Parser)]
+    /// struct Args {
+    ///   input: FileOrStdin,
+    /// }
+    ///
+    /// # #[tokio::main(flavor = "current_thread")]
+    /// # async fn main() -> anyhow::Result<()> {
+    /// let args = Args::parse();
+    /// let mut reader = args.input.into_async_reader().await?;
+    /// let mut buf = vec![0;8];
+    /// reader.read_exact(&mut buf).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn into_async_reader(&self) -> Result<impl tokio::io::AsyncRead, StdinError> {
+        let input: std::pin::Pin<Box<dyn tokio::io::AsyncRead + 'static>> = match &self.source {
+            Source::Stdin => Box::pin(tokio::io::stdin()),
+            Source::Arg(filepath) => {
+                let f = tokio::fs::File::open(filepath).await?;
+                Box::pin(f)
             }
         };
         Ok(input)

--- a/tests/fixtures/file_or_stdin_optional_arg.rs
+++ b/tests/fixtures/file_or_stdin_optional_arg.rs
@@ -9,11 +9,24 @@ struct Args {
     second: Option<FileOrStdin<u32>>,
 }
 
+#[cfg(feature = "test_bin")]
 fn main() {
     let args = Args::parse();
     println!(
         "FIRST: {}, SECOND: {:?}",
         args.first,
         args.second.map(|second| second.contents().unwrap()),
+    );
+}
+
+#[cfg(feature = "test_bin_tokio")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    println!(
+        "FIRST: {}, SECOND: {:?}",
+        args.first,
+        args.second
+            .map(|second| second.contents_async().await.unwrap()),
     );
 }

--- a/tests/fixtures/file_or_stdin_positional_arg.rs
+++ b/tests/fixtures/file_or_stdin_positional_arg.rs
@@ -10,11 +10,23 @@ struct Args {
     second: Option<String>,
 }
 
+#[cfg(feature = "test_bin")]
 fn main() {
     let args = Args::parse();
     println!(
         "FIRST: {}; SECOND: {:?}",
         args.first.contents().unwrap(),
+        args.second
+    );
+}
+
+#[cfg(feature = "test_bin_tokio")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    println!(
+        "FIRST: {}; SECOND: {:?}",
+        args.first.contents_async().await.unwrap(),
         args.second
     );
 }

--- a/tests/fixtures/file_or_stdin_twice.rs
+++ b/tests/fixtures/file_or_stdin_twice.rs
@@ -8,11 +8,23 @@ struct Args {
     second: MaybeStdin<u32>,
 }
 
+#[cfg(feature = "test_bin")]
 fn main() {
     let args = Args::parse();
     println!(
         "FIRST: {}; SECOND: {}",
         args.first.contents().unwrap(),
+        args.second
+    );
+}
+
+#[cfg(feature = "test_bin_tokio")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    println!(
+        "FIRST: {}; SECOND: {}",
+        args.first.contents_async().unwrap(),
         args.second
     );
 }


### PR DESCRIPTION
Adding `tokio` feature to use `tokio::fs::File` and `tokio::io::stdin`
    as suggested in #4.
    
    - Adding `tokio` specific tests, and modifying examples/test_bins to
      test async usage.
    - Not adding support to `MaybeStdin` since clap::parse() blocks and
      contents are read only once when args are parsed anyway