### PR TITLE
Remove an unused `use` declaration in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ input=testing
 ## Compatible Types
 [`FileOrStdin`] can wrap any type that matches the trait bounds for `Arg`: `FromStr` and `Clone`
 ```rust
-use std::path::PathBuf;
 use clap::Parser;
 use clap_stdin::FileOrStdin;
 


### PR DESCRIPTION
It appears `PathBuf` is unused here and can be removed since `u32` is used in this example.