### PR TITLE
Check for duplicate stdin usage on read instead of arg parsing

### DIFF
--- a/src/maybe_stdin.rs
+++ b/src/maybe_stdin.rs
@@ -1,4 +1,3 @@
-use std::io::{self, Read};
 use std::str::FromStr;
 
 use super::{Source, StdinError};
@@ -27,8 +26,6 @@ use super::{Source, StdinError};
 /// ```
 #[derive(Clone)]
 pub struct MaybeStdin<T> {
-    /// Source of the contents
-    pub source: Source,
     inner: T,
 }
 
@@ -41,19 +38,9 @@ where
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let source = Source::from_str(s)?;
-        match &source {
-            Source::Stdin => {
-                let stdin = io::stdin();
-                let mut input = String::new();
-                stdin.lock().read_to_string(&mut input)?;
-                Ok(T::from_str(input.trim_end())
-                    .map_err(|e| StdinError::FromStr(format!("{e}")))
-                    .map(|val| Self { source, inner: val })?)
-            }
-            Source::Arg(value) => Ok(T::from_str(value)
-                .map_err(|e| StdinError::FromStr(format!("{e}")))
-                .map(|val| Self { source, inner: val })?),
-        }
+        T::from_str(source.get_value()?.trim())
+            .map_err(|e| StdinError::FromStr(format!("{e}")))
+            .map(|val| Self { inner: val })
     }
 }
 

--- a/tests/fixtures/file_or_stdin_positional_arg.rs
+++ b/tests/fixtures/file_or_stdin_positional_arg.rs
@@ -11,13 +11,14 @@ struct Args {
 }
 
 #[cfg(feature = "test_bin")]
-fn main() {
+fn main() -> Result<(), String> {
     let args = Args::parse();
     println!(
         "FIRST: {}; SECOND: {:?}",
-        args.first.contents().unwrap(),
+        args.first.contents().map_err(|e| format!("{e}"))?,
         args.second
     );
+    Ok(())
 }
 
 #[cfg(feature = "test_bin_tokio")]
@@ -26,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     println!(
         "FIRST: {}; SECOND: {:?}",
-        args.first.contents_async().await.unwrap(),
+        args.first.contents_async().await?,
         args.second
     );
 }

--- a/tests/fixtures/file_or_stdin_twice.rs
+++ b/tests/fixtures/file_or_stdin_twice.rs
@@ -9,13 +9,15 @@ struct Args {
 }
 
 #[cfg(feature = "test_bin")]
-fn main() {
+fn main() -> Result<(), String> {
     let args = Args::parse();
     println!(
-        "FIRST: {}; SECOND: {}",
-        args.first.contents().unwrap(),
+        "FIRST: {}; SECOND: {:?}",
+        args.first.contents().map_err(|e| format!("{e}"))?,
         args.second
     );
+
+    Ok(())
 }
 
 #[cfg(feature = "test_bin_tokio")]
@@ -24,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     println!(
         "FIRST: {}; SECOND: {}",
-        args.first.contents_async().unwrap(),
+        args.first.contents_async()?,
         args.second
     );
 }


### PR DESCRIPTION
This change relaxes the check for duplicate usage of `stdin` on arg declarations (error at runtime if any two args use `MaybeStdin` or `FileOrStdin`) and instead only check for duplicated `stdin` usage when these args are accessed. This allows usages of args that may be mutually exclusive (E.g. under different subcommands) or use the `global=true` clap option (as reported in #9)

This is likely what I originally intended to do, as the description above matches the duplicate `stdin` usage section in the `README`; if a tool happens to accept multiple args that can be Stdin, the CLI user will only see an error if they actually try to use `stdin` for values twice.