### PR TITLE
[chore] Upgrade tokio dep & bump version to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clap-stdin"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Mat Wood <thepacketgeek@users.noreply.github.com>"]
 description = "Provides a type for easily accepting Clap arguments from stdin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ test_bin_tokio = ["clap", "tokio"]
 [dependencies]
 thiserror = "2.0"
 clap = { version = "4.5", features = ["derive"], optional = true }
-tokio = { version = "1.43", features = [
+tokio = { version = "1.47", features = [
     "fs",
     "io-std",
     "io-util",
@@ -32,10 +32,10 @@ anyhow = "1.0"
 assert_cmd = "2.0"
 predicates = "3.1"
 clap = { version = "4.5", features = ["derive"] }
-tempfile = "3.10"
+tempfile = "3.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.37", features = ["rt", "macros"] }
+tokio = { version = "1.47", features = ["rt", "macros"] }
 
 
 [[example]]


### PR DESCRIPTION
Bumping tokio to 1.47 and upgrading this crate version to 0.7.0