### PR TITLE
Add FileOrStdout for proxying file/stdout when writing output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,17 @@ path = "tests/fixtures/is_stdin.rs"
 test = false
 bench = false
 required-features = ["test_bin"]
+
+[[bin]]
+name = "file_or_stdout_positional_arg"
+path = "tests/fixtures/file_or_stdout_positional_arg.rs"
+test = false
+bench = false
+required-features = ["test_bin"]
+
+[[bin]]
+name = "file_or_stdout_optional_arg"
+path = "tests/fixtures/file_or_stdout_optional_arg.rs"
+test = false
+bench = false
+required-features = ["test_bin"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ from `stdin`, the user will pass the commonly used `stdin` alias: `-`
 
 - `MaybeStdin`: Used when a value can be passed in via args OR `stdin`
 - `FileOrStdin`: Used when a value can be read in from a file OR `stdin`
+- `FileOrStdout`: Used to proxy as a writer for either a file OR `stdout`
 
 ## `MaybeStdin`
 
@@ -102,6 +103,39 @@ $ cat myfile.txt
 $ .example myfile.txt
 ```
 
+## `FileOrStdout`
+
+Example usage with `clap`'s `derive` feature for a positional argument:
+```rust,no_run
+use std::io::Write;
+use clap::Parser;
+use clap_stdin::FileOrStdout;
+
+#[derive(Debug, Parser)]
+struct Args {
+    output: FileOrStdout,
+}
+
+# fn main() -> anyhow::Result<()> {
+let args = Args::parse();
+let mut writer = args.output.into_writer()?;
+writeln!(&mut writer, "testing");
+# Ok(())
+# }
+```
+
+Calling this CLI:
+```sh
+# using stdout for positional arg value
+$ cargo run -- -
+testing
+
+# using filename for positional arg value
+$ cargo run -- output.txt
+$ cat output.txt
+testing
+```
+
 ## Reading from Stdin without special characters
 When using [`MaybeStdin`] or [`FileOrStdin`], you can allow your users to omit the "-" character to read from `stdin` by providing a `default_value` to clap.
 
@@ -138,7 +172,7 @@ input=testing
 ```
 
 ## Async Support
-`FileOrStdin` can also be used with [`tokio::io::AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html) using the `tokio` feature. See [`FileOrStdin::contents_async`] and [`FileOrStdin::into_async_reader`] for examples.
+`FileOrStdin` and `FileOrStdout` can also be used with [`tokio::io::AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html) and [`tokio::io::AsyncWrite`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html) respectively, using the `tokio` feature. See [`FileOrStdin::contents_async`], [`FileOrStdin::into_async_reader`], and [`FileOrStdout::into_async_writer`] for examples.
 
 # Using `MaybeStdin` or `FileOrStdin` multiple times
 Both [`MaybeStdin`] and [`FileOrStdin`] will check at runtime if `stdin` is being read from multiple times. You can use this

--- a/src/file_or_stdout.rs
+++ b/src/file_or_stdout.rs
@@ -1,0 +1,141 @@
+use std::str::FromStr;
+
+use super::Dest;
+
+/// `FileOrStdout` can be used as a proxy output writer to write to whichever destination
+/// was specified by the CLI args, a file or `stdout`.
+///
+/// ```rust
+/// use std::path::PathBuf;
+/// use std::io::Write;
+/// use clap::Parser;
+/// use clap_stdin::FileOrStdout;
+///
+/// #[derive(Debug, Parser)]
+/// struct Args {
+///     output: FileOrStdout,
+/// }
+///
+/// # fn main() -> anyhow::Result<()> {
+/// if let Ok(args) = Args::try_parse() {
+///     let mut writer = args.output.into_writer()?;
+///     write!(&mut writer, "1 2 3 4");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ```sh
+/// $ ./example output.txt
+/// 1 2 3 4
+/// $ cat output.txt | ./example -
+/// 1 2 3 4
+/// ```
+#[derive(Debug, Clone)]
+pub struct FileOrStdout {
+    dest: Dest,
+}
+
+impl FileOrStdout {
+    /// Was this value read from stdout
+    pub fn is_stdout(&self) -> bool {
+        matches!(self.dest, Dest::Stdout)
+    }
+
+    /// Was this value read from a file (path passed in from argument values)
+    pub fn is_file(&self) -> bool {
+        !self.is_stdout()
+    }
+
+    /// The value passed to this arg (Either "-" for stdout or a filepath)
+    pub fn filename(&self) -> &str {
+        match &self.dest {
+            Dest::Stdout => "-",
+            Dest::Arg(path) => path,
+        }
+    }
+
+    /// Create a writer for the dest, to allow user flexibility of
+    /// how to write output (e.g. all at once or in chunks)
+    ///
+    /// ```no_run
+    /// use std::io::Write;
+    ///
+    /// use clap_stdin::FileOrStdout;
+    /// use clap::Parser;
+    ///
+    /// #[derive(Parser)]
+    /// struct Args {
+    ///   output: FileOrStdout,
+    /// }
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let args = Args::parse();
+    /// let mut writer = args.output.into_writer()?;
+    /// let mut buf = vec![0;8];
+    /// writer.write_all(&mut buf)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn into_writer(self) -> Result<impl std::io::Write, std::io::Error> {
+        self.dest.into_writer()
+    }
+
+    #[cfg(feature = "tokio")]
+    /// Create a reader from the source, to allow user flexibility of
+    /// how to read and parse (e.g. all at once or in chunks)
+    ///
+    /// ```no_run
+    /// use std::io::Write;
+    /// use tokio::io::AsyncWriteExt;
+    ///
+    /// use clap_stdin::FileOrStdout;
+    /// use clap::Parser;
+    ///
+    /// #[derive(Parser)]
+    /// struct Args {
+    ///   output: FileOrStdout,
+    /// }
+    ///
+    /// # #[tokio::main(flavor = "current_thread")]
+    /// # async fn main() -> anyhow::Result<()> {
+    /// let args = Args::parse();
+    /// let mut writer = args.output.into_async_writer().await?;
+    /// let mut buf = vec![0;8];
+    /// writer.write_all(&mut buf).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn into_async_writer(&self) -> std::io::Result<impl tokio::io::AsyncWrite> {
+        let output: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + 'static>> = match &self.dest {
+            Dest::Stdout => Box::pin(tokio::io::stdout()),
+            Dest::Arg(filepath) => {
+                let f = tokio::fs::File::open(filepath).await?;
+                Box::pin(f)
+            }
+        };
+        Ok(output)
+    }
+}
+
+impl FromStr for FileOrStdout {
+    type Err = std::io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let dest = Dest::from_str(s)?;
+        Ok(Self { dest })
+    }
+}
+
+#[test]
+fn test_source_methods() {
+    let val: FileOrStdout = "-".parse().unwrap();
+    assert!(val.is_stdout());
+    assert!(!val.is_file());
+    assert_eq!(val.filename(), "-");
+
+    let val: FileOrStdout = "/path/to/something".parse().unwrap();
+    assert!(val.is_file());
+    assert!(!val.is_stdout());
+    assert_eq!(val.filename(), "/path/to/something");
+}

--- a/tests/fixtures/file_or_stdout_optional_arg.rs
+++ b/tests/fixtures/file_or_stdout_optional_arg.rs
@@ -1,0 +1,30 @@
+#[cfg(feature = "test_bin")]
+use std::io::Write;
+
+use clap::Parser;
+
+use clap_stdin::FileOrStdout;
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[arg(short)]
+    value: String,
+    #[arg(long, default_value = "-")]
+    output: FileOrStdout,
+}
+
+#[cfg(feature = "test_bin")]
+fn main() {
+    let args = Args::parse();
+    let mut writer = args.output.into_writer().unwrap();
+    let _ = writeln!(&mut writer, "{}", args.value);
+}
+
+#[cfg(feature = "test_bin_tokio")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let mut writer = args.output.into_async_writer().await?;
+    tokio::io::AsyncWriteExt::write_all(&mut writer, &args.value.as_bytes()).await?;
+    Ok(())
+}

--- a/tests/fixtures/file_or_stdout_positional_arg.rs
+++ b/tests/fixtures/file_or_stdout_positional_arg.rs
@@ -1,0 +1,30 @@
+#[cfg(feature = "test_bin")]
+use std::io::Write;
+
+use clap::Parser;
+
+use clap_stdin::FileOrStdout;
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[arg(short)]
+    value: String,
+    #[arg(default_value = "-")]
+    output: FileOrStdout,
+}
+
+#[cfg(feature = "test_bin")]
+fn main() {
+    let args = Args::parse();
+    let mut writer = args.output.into_writer().unwrap();
+    let _ = writeln!(&mut writer, "{}", args.value);
+}
+
+#[cfg(feature = "test_bin_tokio")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let mut writer = args.output.into_async_writer().await?;
+    tokio::io::AsyncWriteExt::write_all(&mut writer, &args.value.as_bytes()).await?;
+    Ok(())
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -227,3 +227,59 @@ fn test_is_stdin() {
             r#"FIRST is_stdin: true; SECOND is_stdin: false"#,
         ));
 }
+
+#[test]
+fn test_file_or_stdout_positional_args() {
+    let tmp = tempfile::NamedTempFile::new().expect("couldn't create temp file");
+    let tmp_path = tmp.path().to_str().unwrap();
+
+    Command::cargo_bin("file_or_stdout_positional_arg")
+        .unwrap()
+        .args(["-v", "FILE", tmp_path])
+        .assert()
+        .success();
+    let output = String::from_utf8_lossy(&std::fs::read(&tmp_path).unwrap()).to_string();
+    assert_eq!(&output, "FILE\n");
+
+    Command::cargo_bin("file_or_stdout_positional_arg")
+        .unwrap()
+        .args(["-v", "FILE", "-"])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with(r#"FILE"#));
+
+    Command::cargo_bin("file_or_stdout_positional_arg")
+        .unwrap()
+        .args(["-v", "FILE"])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with(r#"FILE"#));
+}
+
+#[test]
+fn test_file_or_stdout_optional_args() {
+    let tmp = tempfile::NamedTempFile::new().expect("couldn't create temp file");
+    let tmp_path = tmp.path().to_str().unwrap();
+
+    Command::cargo_bin("file_or_stdout_optional_arg")
+        .unwrap()
+        .args(["-v", "FILE", "--output", tmp_path])
+        .assert()
+        .success();
+    let output = String::from_utf8_lossy(&std::fs::read(&tmp_path).unwrap()).to_string();
+    assert_eq!(&output, "FILE\n");
+
+    Command::cargo_bin("file_or_stdout_optional_arg")
+        .unwrap()
+        .args(["-v", "FILE", "--output", "-"])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with(r#"FILE"#));
+
+    Command::cargo_bin("file_or_stdout_optional_arg")
+        .unwrap()
+        .args(["-v", "FILE"])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with(r#"FILE"#));
+}


### PR DESCRIPTION
Hoping to address #13 from @ matthiasbeyer by adding a new `FileOrStdout` type that can be used to get a writer for whatever output destination (file or stdout) that the user specifies.

- Can be used as either a positional or optional arg
- Also has async support via "tokio" feature