### PR TITLE
[chore] Replace deprecated assert_cmd::Command::cargo_bin usage

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 use std::fs;
 
+use assert_cmd::cargo_bin;
 use assert_cmd::Command;
 use predicates::prelude::*;
 
@@ -7,16 +8,14 @@ use clap_stdin::StdinError;
 
 #[test]
 fn test_maybe_stdin_positional_arg() {
-    Command::cargo_bin("maybe_stdin_positional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("maybe_stdin_positional_arg"))
         .args(["FIRST", "--second", "SECOND"])
         .assert()
         .success()
         .stdout(predicate::str::starts_with(
             r#"Args { first: "FIRST", second: Some("SECOND") }"#,
         ));
-    Command::cargo_bin("maybe_stdin_positional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("maybe_stdin_positional_arg"))
         .args(["-", "--second", "SECOND"])
         .write_stdin("TESTING")
         .assert()
@@ -24,8 +23,7 @@ fn test_maybe_stdin_positional_arg() {
         .stdout(predicate::str::starts_with(
             r#"Args { first: "TESTING", second: Some("SECOND") }"#,
         ));
-    Command::cargo_bin("maybe_stdin_positional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("maybe_stdin_positional_arg"))
         .args(["FIRST"])
         .write_stdin("TESTING")
         .assert()
@@ -37,16 +35,14 @@ fn test_maybe_stdin_positional_arg() {
 
 #[test]
 fn test_maybe_stdin_optional_arg() {
-    Command::cargo_bin("maybe_stdin_optional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("maybe_stdin_optional_arg"))
         .args(["FIRST", "--second", "2"])
         .assert()
         .success()
         .stdout(predicate::str::starts_with(
             r#"Args { first: "FIRST", second: Some(2) }"#,
         ));
-    Command::cargo_bin("maybe_stdin_optional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("maybe_stdin_optional_arg"))
         .write_stdin("2\n")
         .args(["FIRST", "--second", "-"])
         .assert()
@@ -54,8 +50,7 @@ fn test_maybe_stdin_optional_arg() {
         .stdout(predicate::str::starts_with(
             r#"Args { first: "FIRST", second: Some(2) }"#,
         ));
-    Command::cargo_bin("maybe_stdin_optional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("maybe_stdin_optional_arg"))
         .args(["FIRST"])
         .write_stdin("TESTING")
         .assert()
@@ -67,16 +62,14 @@ fn test_maybe_stdin_optional_arg() {
 
 #[test]
 fn test_maybe_stdin_twice() {
-    Command::cargo_bin("maybe_stdin_twice")
-        .unwrap()
+    Command::new(cargo_bin!("maybe_stdin_twice"))
         .args(["FIRST", "2"])
         .assert()
         .success()
         .stdout(predicate::str::starts_with(
             r#"Args { first: "FIRST", second: 2 }"#,
         ));
-    Command::cargo_bin("maybe_stdin_twice")
-        .unwrap()
+    Command::new(cargo_bin!("maybe_stdin_twice"))
         .write_stdin("2")
         .args(["FIRST", "-"])
         .assert()
@@ -86,8 +79,7 @@ fn test_maybe_stdin_twice() {
         ));
 
     // Actually using stdin twice will fail because there's no value the second time
-    Command::cargo_bin("maybe_stdin_twice")
-        .unwrap()
+    Command::new(cargo_bin!("maybe_stdin_twice"))
         .write_stdin("3")
         .args(["-", "-"])
         .assert()
@@ -103,16 +95,14 @@ fn test_file_or_stdin_positional_arg() {
     fs::write(&tmp, "FILE").expect("couldn't write to temp file");
     let tmp_path = tmp.path().to_str().unwrap();
 
-    Command::cargo_bin("file_or_stdin_positional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdin_positional_arg"))
         .args([&tmp_path, "--second", "SECOND"])
         .assert()
         .success()
         .stdout(predicate::str::starts_with(
             r#"FIRST: FILE; SECOND: Some("SECOND")"#,
         ));
-    Command::cargo_bin("file_or_stdin_positional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdin_positional_arg"))
         .args(["--second", "SECOND"])
         .write_stdin("STDIN")
         .assert()
@@ -120,8 +110,7 @@ fn test_file_or_stdin_positional_arg() {
         .stdout(predicate::str::starts_with(
             r#"FIRST: STDIN; SECOND: Some("SECOND")"#,
         ));
-    Command::cargo_bin("file_or_stdin_positional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdin_positional_arg"))
         .args([&tmp_path])
         .write_stdin("TESTING")
         .assert()
@@ -136,16 +125,14 @@ fn test_file_or_stdin_optional_arg() {
     fs::write(&tmp, "2").expect("couldn't write to temp file");
     let tmp_path = tmp.path().to_str().unwrap();
 
-    Command::cargo_bin("file_or_stdin_optional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdin_optional_arg"))
         .args(["FIRST", "--second", &tmp_path])
         .assert()
         .success()
         .stdout(predicate::str::starts_with(
             r#"FIRST: FIRST, SECOND: Some(2)"#,
         ));
-    Command::cargo_bin("file_or_stdin_optional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdin_optional_arg"))
         .write_stdin("2\n")
         .args(["FIRST", "--second", "-"])
         .assert()
@@ -153,8 +140,7 @@ fn test_file_or_stdin_optional_arg() {
         .stdout(predicate::str::starts_with(
             r#"FIRST: FIRST, SECOND: Some(2)"#,
         ));
-    Command::cargo_bin("file_or_stdin_optional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdin_optional_arg"))
         .args(["FIRST"])
         .write_stdin("TESTING")
         .assert()
@@ -168,14 +154,12 @@ fn test_file_or_stdin_twice() {
     fs::write(&tmp, "FILE").expect("couldn't write to temp file");
     let tmp_path = tmp.path().to_str().unwrap();
 
-    Command::cargo_bin("file_or_stdin_twice")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdin_twice"))
         .args([&tmp_path, "2"])
         .assert()
         .success()
         .stdout(predicate::str::starts_with(r#"FIRST: FILE; SECOND: 2"#));
-    Command::cargo_bin("file_or_stdin_twice")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdin_twice"))
         .write_stdin("2")
         .args([&tmp_path, "-"])
         .assert()
@@ -183,8 +167,7 @@ fn test_file_or_stdin_twice() {
         .stdout(predicate::str::starts_with(r#"FIRST: FILE; SECOND: 2"#));
 
     // Actually using stdin twice will fail because there's no value the second time
-    Command::cargo_bin("file_or_stdin_twice")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdin_twice"))
         .write_stdin("3")
         .args(["-", "-"])
         .assert()
@@ -200,16 +183,14 @@ fn test_is_stdin() {
     fs::write(&tmp, "FILE").expect("couldn't write to temp file");
     let tmp_path = tmp.path().to_str().unwrap();
 
-    Command::cargo_bin("is_stdin")
-        .unwrap()
+    Command::new(cargo_bin!("is_stdin"))
         .args([&tmp_path, "2"])
         .assert()
         .success()
         .stdout(predicate::str::contains(
             r#"FIRST is_stdin: false; SECOND is_stdin: false"#,
         ));
-    Command::cargo_bin("is_stdin")
-        .unwrap()
+    Command::new(cargo_bin!("is_stdin"))
         .write_stdin("2")
         .args([&tmp_path, "-"])
         .assert()
@@ -217,8 +198,7 @@ fn test_is_stdin() {
         .stdout(predicate::str::contains(
             r#"FIRST is_stdin: false; SECOND is_stdin: true"#,
         ));
-    Command::cargo_bin("is_stdin")
-        .unwrap()
+    Command::new(cargo_bin!("is_stdin"))
         .write_stdin("testing")
         .args(["-", "2"])
         .assert()
@@ -233,23 +213,20 @@ fn test_file_or_stdout_positional_args() {
     let tmp = tempfile::NamedTempFile::new().expect("couldn't create temp file");
     let tmp_path = tmp.path().to_str().unwrap();
 
-    Command::cargo_bin("file_or_stdout_positional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdout_positional_arg"))
         .args(["-v", "FILE", tmp_path])
         .assert()
         .success();
     let output = String::from_utf8_lossy(&std::fs::read(&tmp_path).unwrap()).to_string();
     assert_eq!(&output, "FILE\n");
 
-    Command::cargo_bin("file_or_stdout_positional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdout_positional_arg"))
         .args(["-v", "FILE", "-"])
         .assert()
         .success()
         .stdout(predicate::str::starts_with(r#"FILE"#));
 
-    Command::cargo_bin("file_or_stdout_positional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdout_positional_arg"))
         .args(["-v", "FILE"])
         .assert()
         .success()
@@ -261,23 +238,20 @@ fn test_file_or_stdout_optional_args() {
     let tmp = tempfile::NamedTempFile::new().expect("couldn't create temp file");
     let tmp_path = tmp.path().to_str().unwrap();
 
-    Command::cargo_bin("file_or_stdout_optional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdout_optional_arg"))
         .args(["-v", "FILE", "--output", tmp_path])
         .assert()
         .success();
     let output = String::from_utf8_lossy(&std::fs::read(&tmp_path).unwrap()).to_string();
     assert_eq!(&output, "FILE\n");
 
-    Command::cargo_bin("file_or_stdout_optional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdout_optional_arg"))
         .args(["-v", "FILE", "--output", "-"])
         .assert()
         .success()
         .stdout(predicate::str::starts_with(r#"FILE"#));
 
-    Command::cargo_bin("file_or_stdout_optional_arg")
-        .unwrap()
+    Command::new(cargo_bin!("file_or_stdout_optional_arg"))
         .args(["-v", "FILE"])
         .assert()
         .success()


### PR DESCRIPTION
Fixing #15 by replacing deprecated and soon to be broken `assert_cmd::Command::cargo_bin` usage with
`assert_cmd::Command::new(assert_cmd::cargo_bin!())`