### PR TITLE
Fix FileOrStdout truncate = false

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl Dest {
                 let f = std::fs::OpenOptions::new()
                     .create(true)
                     .write(true)
-                    .truncate(false)
+                    .truncate(true)
                     .open(filepath)?;
                 Box::new(f)
             }


### PR DESCRIPTION
`FileOrStdout` was previously added with `OpenOptions` that set `truncate` == false. This was a bug for two reasons:

1) If a user is writing to an existing file, the cursor index would be
   set to 0, but file contents would persist. If the new output is
shorter than the existing contents, trailing existing contents would still exist.

2) If a user specifies a file to output, it's most likely that they want
   to completely overwrite file contents, not append (reported in #17)

(Resolves #17 