### PR TITLE
Add clap_complete compatibility test and note in README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,13 @@ repository = "https://github.com/thepacketgeek/clap-stdin"
 default = []
 tokio = ["dep:tokio"]
 # This feature is used for testing with the bins below, since they are linked with deps and not dev-deps
-test_bin = ["clap"]
-test_bin_tokio = ["clap", "tokio"]
+test_bin = ["clap", "clap_complete"]
+test_bin_tokio = ["clap", "tokio", "clap_complete"]
 
 [dependencies]
 thiserror = "2.0"
 clap = { version = "4.6", features = ["derive"], optional = true }
+clap_complete = { version = "4.6", features = ["unstable-dynamic"], optional = true }
 tokio = { version = "1.53", features = [
     "fs",
     "io-std",
@@ -32,6 +33,7 @@ anyhow = "1.0"
 assert_cmd = "2.2"
 predicates = "3.1"
 clap = { version = "4.6", features = ["derive"] }
+clap_complete = { version = "4.6", features = ["unstable-dynamic"] }
 tempfile = "3.27"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -46,6 +48,13 @@ required-features = ["default"]
 [[bin]]
 name = "maybe_stdin_positional_arg"
 path = "tests/fixtures/maybe_stdin_positional_arg.rs"
+test = false
+bench = false
+required-features = ["test_bin"]
+
+[[bin]]
+name = "file_or_stdin_completion"
+path = "tests/fixtures/file_or_stdin_completion.rs"
 test = false
 bench = false
 required-features = ["test_bin"]

--- a/README.md
+++ b/README.md
@@ -201,6 +201,24 @@ $ echo "2" | ./example - -
 error: invalid value '-' for '<SECOND>': stdin argument used more than once
 ```
 
+# Using `MaybeStdin` or `FileOrStdin` with `clap_complete`
+Shell completions generated with `clap_complete` do not work with `MaybeStdin` and `FileOrStdin` by default, but @quantenzitrone found a solution using [`PathCompleter::stdio()`](https://docs.rs/clap_complete/latest/clap_complete/engine/struct.PathCompleter.html#method.stdio):
+
+```rust
+use clap::{CommandFactory, Parser};
+use clap_complete::engine::{ArgValueCompleter, PathCompleter, ValueCompleter};
+use clap_stdin::FileOrStdin;
+
+#[derive(Debug, Parser)]
+#[command()]
+struct Args {
+    #[arg(add = ArgValueCompleter::new(|x: &std::ffi::OsStr| PathCompleter::file().stdio().complete(x)), default_value = "-")]
+    value: FileOrStdin,
+}
+```
+
+See [`file_or_stdin_completion.rs`](tests/fixtures/file_or_stdin_completion.rs) for a full example.
+
 # License
 
 `clap-stdin` is both MIT and Apache License, Version 2.0 licensed, as found

--- a/tests/fixtures/file_or_stdin_completion.rs
+++ b/tests/fixtures/file_or_stdin_completion.rs
@@ -1,0 +1,32 @@
+use clap::{CommandFactory, Parser};
+
+use clap_complete::engine::{ArgValueCompleter, PathCompleter, ValueCompleter};
+use clap_stdin::FileOrStdin;
+
+#[derive(Debug, Parser)]
+#[command()]
+struct Args {
+    #[arg(add = ArgValueCompleter::new(|x: &std::ffi::OsStr| PathCompleter::file().stdio().complete(x)), default_value = "-")]
+    value: FileOrStdin,
+}
+
+#[cfg(feature = "test_bin")]
+fn main() -> Result<(), String> {
+    clap_complete::CompleteEnv::with_factory(Args::command).complete();
+
+    let args = Args::parse();
+    println!(
+        "VALUE: {}",
+        args.value.contents().map_err(|e| format!("{e}"))?
+    );
+    Ok(())
+}
+
+#[cfg(feature = "test_bin_tokio")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    clap_complete::CompleteEnv::with_factory(Args::command).complete();
+
+    let args = Args::parse();
+    println!("VALUE: {}", args.value.contents_async().await?);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -119,6 +119,25 @@ fn test_file_or_stdin_positional_arg() {
 }
 
 #[test]
+fn test_file_or_stdin_completion() {
+    let tmp = tempfile::NamedTempFile::new().expect("couldn't create temp file");
+    fs::write(&tmp, "FILE").expect("couldn't write to temp file");
+    let tmp_path = tmp.path().to_str().unwrap();
+
+    Command::new(cargo_bin!("file_or_stdin_completion"))
+        .args([&tmp_path])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with(r#"VALUE: FILE"#));
+    Command::new(cargo_bin!("file_or_stdin_completion"))
+        .args([&tmp_path])
+        .write_stdin("TESTING")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with(r#"VALUE: FILE"#));
+}
+
+#[test]
 fn test_file_or_stdin_optional_arg() {
     let tmp = tempfile::NamedTempFile::new().expect("couldn't create temp file");
     // In this case, --second is `Option<FileOrStdin<u32>>` so we'll have a number in the file


### PR DESCRIPTION
Add a test that builds w/ `clap_complete` and a note in the README about @quantenzitrone's findings for getting these types to work with `clap_complete`